### PR TITLE
Compatibility: fixing missing var in _CCW()

### DIFF
--- a/js/polysplitting.js
+++ b/js/polysplitting.js
@@ -796,10 +796,13 @@
     // tests if points rotate counter clockwise
     // returns boolean
     function _CCW(p1, p2, p3) {
-      a = p1.lng(); b = p1.lat();
-      c = p2.lng(); d = p2.lat();
-      e = p3.lng(); f = p3.lat();
-
+      var a = p1.lng(); 
+      var b = p1.lat();
+      var c = p2.lng(); 
+      var d = p2.lat();
+      var e = p3.lng(); 
+      var f = p3.lat();
+      
       return (f - b) * (c - a) > (d - b) * (e - a);
     }
 


### PR DESCRIPTION
Including this Lib in minify-processes throws errors, because a to f in function _CCW are not declared as variables.